### PR TITLE
Delete token.json, update attachment logic

### DIFF
--- a/mail.js
+++ b/mail.js
@@ -34,7 +34,7 @@ class Mail{
         // Do not generate invoice if attachments are missing.
         if(err){
     			return console.log(`Error compiling email: ${err}`);
-    		} else if(!encodedAttachments.length){
+    		} else if(encodedAttachments.length < 2){
           return console.log(`Will not generate invoice: Attachments missing for ${self.company}`);
         }
 


### PR DESCRIPTION
The team has requested that we do not generate invoices for clients that have fewer than two attachments available in the invoices directory. Additionally, the token.json should not exist, in order to generate the token in the first place.