### PR TITLE
Html email capability

### DIFF
--- a/attachments.js
+++ b/attachments.js
@@ -8,8 +8,8 @@ class Attachments {
     this.id = id;
   }
 
- // Encodes attachments.
- encodedList(callback){
+  // Encodes attachments.
+  encodedList(callback){
     this.getInvoices(function(err, invoices){
       if(err){
         return console.log(err);

--- a/email_body.html
+++ b/email_body.html
@@ -1,0 +1,22 @@
+<p>Hello,</p>
+
+<p>Attached please find the November 2019 Incentive Invoice along with the supporting report(s). Please process the invoice for payment and contact us if you have any questions or require additional information.</p>
+
+<p>Thank you,</p>
+
+<div>
+  <p>
+    Jacqueline M. Aponte<br>
+    <span style="color: #FF0080"><strong>Staff Accountant</strong></span><br>
+    <span style="color: #00008b"><strong>Sapphire Digital</strong></span><br>
+    160 Chubb Avenue, Suite 301<br>
+    Lyndhurst, NJ 07071<br>
+    P: 646.560.1965 E:
+    <a href="Jacqueline.aponte@sapphire-digital.com">Jacqueline.aponte@sapphire-digital.com</a><br>
+    <a href="https://www.sapphire-digital.com">https://www.sapphire-digital.com</a>
+  </p>
+</div>
+
+<img width="30%" src="https://www.sapphire-digital.com/wp-content/uploads/2019/02/opt_Sapphire-Logo-TM-Version-01-e1547829180959_250.png">
+
+<p style="color: white">zixencrypt</p>

--- a/email_body.txt
+++ b/email_body.txt
@@ -1,9 +1,0 @@
-Hello,
-
-Attached please find the November 2019 Incentive Invoice along with the supporting report(s). Please process the invoice for payment and contact us if you have any questions or require additional information.
-
-Thank you,
-
-Gretchen Ziegler
-
-zixencrypt

--- a/mail.js
+++ b/mail.js
@@ -17,80 +17,80 @@ class Mail{
     this.subject = `November 2019 Invoice for ${companyName}`;
 
     try {
-      this.body = fs.readFileSync('email_body.txt', 'utf8');
+      this.body = fs.readFileSync('email_body.html', 'utf8');
     } catch(e) {
       throw(`Error: ${e}`);
     }
   }
 
   createMail(){
-  	// Get attachments, compile, encode, and send mail.
+    // Get attachments, compile, encode, and send mail.
     let self = this;
 
     let attachments = new Attachments(this.employerGroupId);
 
     attachments.encodedList(function(encodedAttachments){
-    	self.composeMail(self, encodedAttachments).compile().build((err, msg) => {
+      self.composeMail(self, encodedAttachments).compile().build((err, msg) => {
         // Do not generate invoice if attachments are missing.
         if(err){
-    			return console.log(`Error compiling email: ${err}`);
-    		} else if(encodedAttachments.length < 2){
+          return console.log(`Error compiling email: ${err}`);
+        } else if(encodedAttachments.length < 2){
           return console.log(`Will not generate invoice: Attachments missing for ${self.company}`);
         }
 
-    		const encodedMessage = Buffer.from(msg)
-    			.toString('base64')
-  			  .replace(/\+/g, '-')
-  			  .replace(/\//g, '_')
-  			  .replace(/=+$/, '');
+        const encodedMessage = Buffer.from(msg)
+          .toString('base64')
+          .replace(/\+/g, '-')
+          .replace(/\//g, '_')
+          .replace(/=+$/, '');
 
-  			// If the task is 'mail', send automatically. Otherwise, create draft.
-  			if(self.task === 'mail'){
-  				self.sendMail(encodedMessage);
-  			} else {
-  				self.saveDraft(encodedMessage);
-  			}
-    	});
+        // If the task is 'mail', send automatically. Otherwise, create draft.
+        if(self.task === 'mail'){
+          self.sendMail(encodedMessage);
+        } else {
+          self.saveDraft(encodedMessage);
+        }
+      });
     });
   }
 
   // Compose mail.
   composeMail(self, attachments){
-		return new mailComposer({
-			to: self.to,
-			text: self.body,
-			subject: self.subject,
-			textEncoding: 'base64',
-			attachments: attachments
-		});
+    return new mailComposer({
+      to: self.to,
+      html: self.body,
+      subject: self.subject,
+      textEncoding: 'base64',
+      attachments: attachments
+    });
   }
 
   // Send the message to the specified recipient.
   sendMail(encodedMessage){
-  	this.gmail.users.messages.send({
-  		userId: this.from,
-  		resource: {
-  			raw: encodedMessage
-  		}
-  	}, (err, result) => {
-  		if(err){
-  			return console.log(`The API returned an error: ${err}`);
-  		} else {
-  			console.log(`Sending email reply from server: ${result.data}`);
-  		}
-  	});
+    this.gmail.users.messages.send({
+      userId: this.from,
+      resource: {
+        raw: encodedMessage
+      }
+    }, (err, result) => {
+      if(err){
+        return console.log(`The API returned an error: ${err}`);
+      } else {
+        console.log(`Sending email reply from server: ${result.data}`);
+      }
+    });
   }
 
   // Save a draft.
   saveDraft(encodedMessage){
-  	this.gmail.users.drafts.create({
-  		userId: this.from,
-  		resource: {
-  			message: {
-  				raw: encodedMessage
-  			}
-  		}
-  	}, (err, result) => {
+    this.gmail.users.drafts.create({
+      userId: this.from,
+      resource: {
+        message: {
+          raw: encodedMessage
+        }
+      }
+    }, (err, result) => {
       if(err){
         return console.log(`Error creating draft for ${this.company}: ${err}`);
       } else {

--- a/mail.js
+++ b/mail.js
@@ -92,9 +92,9 @@ class Mail{
   		}
   	}, (err, result) => {
       if(err){
-        return console.log(`Error creating draft: ${err}`);
+        return console.log(`Error creating draft for ${this.company}: ${err}`);
       } else {
-        console.log(`Draft created successfully for: ${this.company}`);
+        console.log(`Draft created successfully for ${this.company}`);
       }
     });
   }


### PR DESCRIPTION
We want to be able to automatically send that sweet Sapphire-Digital email signature to our clients, and an easy way to do that is to render the email as HTML. 

This PR does the following:
* Updates the `composeMail` function to send html instead of text
* Deletes `email_body.txt` in favor of `email_body.html`, which includes some sweet inline signature styling
* Updates the spacing in mail.js, which was _not correct_

I don't know why that mail file was spaced so funkily; the other files look okay. It must have been that an initial tab/spacing setting was off on my text editor. In any case, that's the majority of this PR. 