### PR TITLE
Delay Gmail API requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,9 @@ function sendMailers(auth){
   let contacts = new Contacts();
   contacts.getContacts(function(formattedContacts){
     for(let i = 0; i < formattedContacts.length; i++){
-    	new Mail(auth, formattedContacts[i]).createMail();
+      setTimeout(function() {
+        new Mail(auth, formattedContacts[i]).createMail();
+      }, (i * 250));
     }
   });
 }


### PR DESCRIPTION
The GMail API has some [usage limits](https://developers.google.com/gmail/api/v1/reference/quota) that conflict with the generator as it stands. We can post about 40 email drafts or so before we get this sweet error:
```
Error: Too many concurrent requests for user
```
Adding the timeout to the loop forces the script to wait between requests, thereby complying with the concurrent request limit. I went with an arbitrary 250ms (multiplied by the index of the contact), and that seems to be working pretty well for a lift of about 250 emails at a time. We can always increase that timeout if need be.