### PR TITLE
Match attachments against exact employerId

### DIFF
--- a/attachments.js
+++ b/attachments.js
@@ -33,7 +33,8 @@ class Attachments {
       callback(
         err,
         files.filter(function(file){
-          return file.includes(employerId);
+          let id = file.split('_')[0];
+          return id === employerId;
         })
       );
     });


### PR DESCRIPTION
When I did this work initially, I assumed that the `employerId` would be a unique 5-digit code, but it's actually from 4 to _n_ digits long. The finance team caught this missed assumptions when attachments from employer 1234 were added to the invoice for employer 512345 (not the actual ids, but you get the gist).

This PR checks for an exact match on the id, instead of just checking to see that the id is included somewhere within the file name. The finance team has assured me that the file names will all begin with the id, separated from the rest of the file name by an underscore.